### PR TITLE
[semver:minor] Fix and improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,11 +181,11 @@ orbs:
               name: Remember << parameters.env_var >>
               command: |
                 export << parameters.env_var >>="<< parameters.value >>"
-                exporter="export << parameters.env_var >>=${<< parameters.env_var >>}"
+                exporter="export << parameters.env_var >>=\"${<< parameters.env_var >>}\""
                 echo $exporter >> $BASH_ENV
                 remember_file="/tmp/circleci_remember/.circleci_remember/<< parameters.env_var >>"
                 mkdir -p $(dirname $remember_file)
-                echo $exporter >> $remember_file
+                echo ${<< parameters.env_var >>} >> $remember_file
                 echo Remembering << parameters.env_var >> = ${<< parameters.env_var >>}
           - persist_to_workspace:
               # TODO: platform agnostic
@@ -206,7 +206,8 @@ orbs:
           - run:
               name: Recall << parameters.env_var >>
               command: |
-                exporter=$(cat /tmp/circleci_remember/.circleci_remember/<< parameters.env_var >>)
-                $exporter
+                export_value=$(cat /tmp/circleci_remember/.circleci_remember/<< parameters.env_var >>)
+                export << parameters.env_var >>=$export_value
+                exporter="export << parameters.env_var >>=\"$export_value\""
                 echo $exporter >> $BASH_ENV
                 echo Recalled << parameters.env_var >> = ${<< parameters.env_var >>}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,10 +200,15 @@ orbs:
           env_var:
             description: The environment variable to recall.
             type: string
+          when:
+            description: Specify when to recall
+            type: string
+            default: "always"
         steps:
           - attach_workspace:
               at: /tmp/circleci_remember
           - run:
+              when: << parameters.when >>
               name: Recall << parameters.env_var >>
               command: |
                 export_value=$(cat /tmp/circleci_remember/.circleci_remember/<< parameters.env_var >>)


### PR DESCRIPTION
Hello. Thanks for this useful orb.

I've been trying to create an ENV variable with the following:

```
      - remember:
          env_var: GIT_COMMIT_DESC
          value: '$(git log --format=%B -n 1 $CIRCLE_SHA1)'
```

Assuming that value resolves to `My dummy text`. For the remember step value I get:

```
My
```
When trying to recall value I get an error:

```
bash: export: `text"': not a valid identifier
```
Changes I made fix this. Hope they are okay.

Additionally, I'd like to recall only when job failed or succeeded. I added the `when` attribute for this.

Thanks.